### PR TITLE
SR2021 deploy changes

### DIFF
--- a/modules/www/manifests/python_docs.pp
+++ b/modules/www/manifests/python_docs.pp
@@ -11,12 +11,8 @@ class www::python_docs ( $web_root_dir, $version ) {
   $target_dir = "${$target_root}${archive_name}"
 
   # wget is generally nicer than curl for downloading things.
-  package {'wget':
-    ensure => present,
-  }
-
-  # bzip2 is needed to unzip source
-  package {'bzip2':
+  # bzip2 is needed to unzip some things
+  package { ['wget', 'bzip2']: 
     ensure => present,
   }
 
@@ -33,7 +29,7 @@ class www::python_docs ( $web_root_dir, $version ) {
           wget -O - https://www.python.org/ftp/python/doc/${version}/${archive_name}.tar.bz2 | tar -xj -C ${target_root} ",
     provider => 'shell',
     creates => $target_dir,
-    require => [Package['wget'],File[$target_root],Package['bzip2']],
+    require => [Package['wget', 'bzip2'],File[$target_root]],
   }
 
   file { "${web_root_dir}/docs":

--- a/modules/www/manifests/python_docs.pp
+++ b/modules/www/manifests/python_docs.pp
@@ -11,7 +11,12 @@ class www::python_docs ( $web_root_dir, $version ) {
   $target_dir = "${$target_root}${archive_name}"
 
   # wget is generally nicer than curl for downloading things.
-  package { ['wget']:
+  package {'wget':
+    ensure => present,
+  }
+
+  # bzip2 is needed to unzip source
+  package {'bzip2':
     ensure => present,
   }
 
@@ -28,7 +33,7 @@ class www::python_docs ( $web_root_dir, $version ) {
           wget -O - https://www.python.org/ftp/python/doc/${version}/${archive_name}.tar.bz2 | tar -xj -C ${target_root} ",
     provider => 'shell',
     creates => $target_dir,
-    require => [Package['wget'],File[$target_root]],
+    require => [Package['wget'],File[$target_root],Package['bzip2']],
   }
 
   file { "${web_root_dir}/docs":


### PR DESCRIPTION
Make a few changes needed from trying to provision the SR2021 server:

- ~Add `epel` module, as it's a dependency on provisioning LE certs, apparently~
- Install bzip2, as it's required to untar the python docs